### PR TITLE
Fixed possible index errors that caused crashes.

### DIFF
--- a/plugin.video.fox/addon.py
+++ b/plugin.video.fox/addon.py
@@ -45,8 +45,7 @@ def shows(url):
 		page = 2
 	response = get_json(url)
 	jsob = json.loads(response)
-	totalItems = jsob['totalItems']
-	for i in range(totalItems):
+	for i in range(len(jsob['member'])):
 		try:seriesType = jsob['member'][i]['seriesType']
 		except IndexError:
 			continue


### PR DESCRIPTION
I recently started getting errors that crashed the plugin. Found this in the log:

```
21:40:14.449 T:1544663968   ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                             - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                            Error Type: <type 'exceptions.IndexError'>
                                            Error Contents: list index out of range
                                            Traceback (most recent call last):
                                              File "/storage/.kodi/addons/plugin.video.fox/addon.py", line 287, in <module>
                                                shows()
                                              File "/storage/.kodi/addons/plugin.video.fox/addon.py", line 46, in shows
                                                seriesType = jsob['member'][i]['seriesType']
                                            IndexError: list index out of range

```

This change fixed the error for me, so I thought I'd share ;)